### PR TITLE
feat: add explicit dependencies to ensure proper resource creation or…

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -95,6 +95,11 @@ resource "databricks_volume" "volume" {
   name         = var.volume_name
   volume_type  = "MANAGED"
   comment      = "Volume for storing country-currency CSV data files"
+  
+  # Add explicit dependency on schema to ensure proper creation order
+  depends_on = [
+    databricks_schema.schema
+  ]
 }
 
 #----------------------------------------------
@@ -152,7 +157,8 @@ resource "databricks_sql_table" "table" {
   }
 
   depends_on = [
-    # Schema dependency is optional since it might already exist
+    # Explicit schema dependency to ensure proper creation order
+    databricks_schema.schema,
     null_resource.start_warehouse_windows,
     null_resource.start_warehouse_linux
   ]
@@ -220,8 +226,12 @@ resource "databricks_job" "load_data_job" {
   }
 
   depends_on = [
-    # Only depend on resources that are always created
+    # Ensure all required resources are created first
     databricks_notebook.load_data_notebook,
+    databricks_schema.schema,
+    databricks_volume.volume,
+    databricks_sql_table.table,
+    databricks_file.csv_data,
     null_resource.start_warehouse_windows,
     null_resource.start_warehouse_linux
   ]


### PR DESCRIPTION
This pull request updates the Terraform configuration in `terraform/main.tf` to ensure proper creation order of resources by adding explicit `depends_on` dependencies. These changes improve resource dependency management and reduce the likelihood of deployment issues caused by resource creation order.

### Dependency Management Improvements:

* **`databricks_volume` resource**: Added an explicit dependency on `databricks_schema.schema` to ensure the schema is created before the volume.
* **`databricks_sql_table` resource**: Updated the `depends_on` block to explicitly include `databricks_schema.schema`, ensuring the schema is created before the table.
* **`databricks_job` resource**: Expanded the `depends_on` block to include dependencies on `databricks_schema.schema`, `databricks_volume.volume`, `databricks_sql_table.table`, and `databricks_file.csv_data`, ensuring all required resources are created before the job.